### PR TITLE
fix: Players table nested borders issue

### DIFF
--- a/app/ui/game-status/PlayersTableDisplay.story.tsx
+++ b/app/ui/game-status/PlayersTableDisplay.story.tsx
@@ -33,6 +33,9 @@ export function PlayersTableDisplayStory() {
       <section>
         <h2 className="text-lg font-semibold mb-3">Default (4 players)</h2>
         <PlayersTableDisplay players={SAMPLE_PLAYERS} />
+        <p className="text-xs text-muted-foreground mt-2">
+          Clean single border around table with dividers between rows (no nested/double borders).
+        </p>
       </section>
 
       {/* With Active Player (whose turn) */}

--- a/app/ui/game-status/PlayersTableDisplay.tsx
+++ b/app/ui/game-status/PlayersTableDisplay.tsx
@@ -35,17 +35,14 @@ export function PlayersTableDisplay({
             <th className="text-right py-2 px-3 font-medium">Score</th>
           </tr>
         </thead>
-        <tbody>
+        <tbody className="divide-y divide-border">
           {players.map((player) => {
             const isViewingPlayer = player.id === viewingPlayerId;
             const isActivePlayer = player.id === activePlayerId;
             return (
               <tr
                 key={player.id}
-                className={cn(
-                  "border-t border-border",
-                  isActivePlayer && "bg-primary/10"
-                )}
+                className={cn(isActivePlayer && "bg-primary/10")}
               >
                 <td className="py-2 px-3">
                   <span


### PR DESCRIPTION
## Summary
- Replaced individual row borders with `divide-y divide-border` on tbody element
- Eliminates double-line effect where row borders met container border
- Clean single dividers between rows only

Closes #14

## Test plan
- [x] Type check passes
- [x] 2034 tests pass
- [x] Build succeeds
- [x] Visual verification via storybook

🤖 Generated with [Claude Code](https://claude.com/claude-code)