### PR TITLE
fix: Improve mobile tap reliability for ActionBar in drawer (#42)

### DIFF
--- a/app/shadcn/components/ui/button.tsx
+++ b/app/shadcn/components/ui/button.tsx
@@ -24,6 +24,7 @@ const buttonVariants = cva(
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        mobile: "h-11 px-4 py-2.5 has-[>svg]:px-3",
         icon: "size-9",
         "icon-sm": "size-8",
         "icon-lg": "size-10",

--- a/app/ui/action-bar/ActionBar.test.tsx
+++ b/app/ui/action-bar/ActionBar.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { AvailableActions } from "core/engine/game-engine.availability";
+import { ActionBar } from "./ActionBar";
+
+const baseActions: AvailableActions = {
+  canDrawFromStock: false,
+  canDrawFromDiscard: false,
+  canLayDown: false,
+  canLayOff: false,
+  canSwapJoker: false,
+  canDiscard: false,
+  canMayI: false,
+  canAllowMayI: false,
+  canClaimMayI: false,
+  canReorderHand: false,
+  hasPendingMayIRequest: false,
+};
+
+describe("ActionBar touch-optimized mode", () => {
+  it("marks content as no-drag and uses mobile-sized buttons", () => {
+    const html = renderToStaticMarkup(
+      <ActionBar
+        availableActions={{ ...baseActions, canDiscard: true }}
+        onAction={() => {}}
+        touchOptimized
+      />
+    );
+
+    expect(html).toContain("data-vaul-no-drag");
+    expect(html).toContain('data-size="mobile"');
+    expect(html).toContain("h-11");
+  });
+});

--- a/app/ui/action-bar/ActionBar.tsx
+++ b/app/ui/action-bar/ActionBar.tsx
@@ -1,3 +1,4 @@
+import type { ComponentProps } from "react";
 import { Button } from "~/shadcn/components/ui/button";
 import { cn } from "~/shadcn/lib/utils";
 import type { AvailableActions } from "core/engine/game-engine.availability";
@@ -7,6 +8,8 @@ interface ActionBarProps {
   availableActions: AvailableActions;
   /** Called when player performs an action */
   onAction: (action: string) => void;
+  /** Improves tap reliability in touch contexts like drawers */
+  touchOptimized?: boolean;
   className?: string;
 }
 
@@ -19,8 +22,12 @@ interface ActionBarProps {
 export function ActionBar({
   availableActions,
   onAction,
+  touchOptimized = false,
   className,
 }: ActionBarProps) {
+  type ButtonSize = ComponentProps<typeof Button>["size"];
+  const buttonSize: ButtonSize = touchOptimized ? "mobile" : undefined;
+  const organizeButtonSize: ButtonSize = touchOptimized ? "mobile" : "sm";
   const {
     canDrawFromStock,
     canDrawFromDiscard,
@@ -52,71 +59,109 @@ export function ActionBar({
     <div
       className={cn(
         "flex items-center justify-center gap-2 p-3 bg-muted/50 border-t",
+        touchOptimized && "touch-manipulation",
         className
       )}
+      data-vaul-no-drag={touchOptimized ? "" : undefined}
     >
       {/* Draw Phase */}
       {canDrawFromStock && (
-        <Button onClick={() => onAction("drawStock")} variant="default">
+        <Button
+          onClick={() => onAction("drawStock")}
+          variant="default"
+          size={buttonSize}
+        >
           Draw Card
         </Button>
       )}
       {canDrawFromDiscard && (
-        <Button onClick={() => onAction("pickUpDiscard")} variant="outline">
+        <Button
+          onClick={() => onAction("pickUpDiscard")}
+          variant="outline"
+          size={buttonSize}
+        >
           Pick Up Discard
         </Button>
       )}
 
       {/* Action Phase - Lay Down */}
       {canLayDown && (
-        <Button onClick={() => onAction("layDown")} variant="default">
+        <Button
+          onClick={() => onAction("layDown")}
+          variant="default"
+          size={buttonSize}
+        >
           Lay Down
         </Button>
       )}
 
       {/* Action Phase - Lay Off (only when down) */}
       {canLayOff && (
-        <Button onClick={() => onAction("layOff")} variant="default">
+        <Button
+          onClick={() => onAction("layOff")}
+          variant="default"
+          size={buttonSize}
+        >
           Lay Off
         </Button>
       )}
 
       {/* Action Phase - Swap Joker (only when not down, runs with jokers exist) */}
       {canSwapJoker && (
-        <Button onClick={() => onAction("swapJoker")} variant="outline">
+        <Button
+          onClick={() => onAction("swapJoker")}
+          variant="outline"
+          size={buttonSize}
+        >
           Swap Joker
         </Button>
       )}
 
       {/* Discard */}
       {canDiscard && (
-        <Button onClick={() => onAction("discard")} variant="outline">
+        <Button
+          onClick={() => onAction("discard")}
+          variant="outline"
+          size={buttonSize}
+        >
           Discard
         </Button>
       )}
 
       {/* May I - when not your turn */}
       {canMayI && (
-        <Button onClick={() => onAction("mayI")} variant="secondary">
+        <Button
+          onClick={() => onAction("mayI")}
+          variant="secondary"
+          size={buttonSize}
+        >
           May I?
         </Button>
       )}
 
       {/* May I pending - waiting for resolution */}
       {hasPendingMayIRequest && (
-        <Button variant="secondary" disabled>
+        <Button variant="secondary" size={buttonSize} disabled>
           Waiting...
         </Button>
       )}
 
       {/* May I Resolution - Allow/Claim */}
       {canAllowMayI && (
-        <Button onClick={() => onAction("allowMayI")} variant="outline">
+        <Button
+          onClick={() => onAction("allowMayI")}
+          variant="outline"
+          size={buttonSize}
+        >
           Allow
         </Button>
       )}
       {canClaimMayI && (
-        <Button onClick={() => onAction("claimMayI")} variant="default">
+        <Button
+          onClick={() => onAction("claimMayI")}
+          variant="default"
+          size={buttonSize}
+        >
           Claim
         </Button>
       )}
@@ -133,7 +178,7 @@ export function ActionBar({
         <Button
           onClick={() => onAction("organize")}
           variant="ghost"
-          size="sm"
+          size={organizeButtonSize}
           className="ml-2"
         >
           Organize

--- a/app/ui/hand-drawer/HandDrawer.tsx
+++ b/app/ui/hand-drawer/HandDrawer.tsx
@@ -137,7 +137,7 @@ export function HandDrawer({
   );
 
   return (
-    <Drawer.Root open={open} onOpenChange={onOpenChange}>
+    <Drawer.Root open={open} onOpenChange={onOpenChange} handleOnly>
       {!open && (
         <Drawer.Trigger asChild>
           <button
@@ -197,7 +197,7 @@ export function HandDrawer({
         >
           {/* Drag Handle */}
           <div className="flex justify-center pt-3 pb-2 shrink-0">
-            <div className="w-12 h-1.5 bg-muted-foreground/40 rounded-full" />
+            <Drawer.Handle className="!h-1.5 !w-12 !bg-muted-foreground/40 !opacity-100" />
           </div>
 
           <div className="px-4 pb-3">
@@ -238,7 +238,11 @@ export function HandDrawer({
             className="shrink-0"
             style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
           >
-            <ActionBar availableActions={availableActions} onAction={onAction} />
+            <ActionBar
+              availableActions={availableActions}
+              onAction={onAction}
+              touchOptimized
+            />
           </div>
         </Drawer.Content>
       </Drawer.Portal>


### PR DESCRIPTION
## Summary
- Fixes unreliable tap detection on ActionBar buttons (Discard, Lay Down, etc.) when rendered inside the mobile hand drawer
- Root cause was Vaul drawer intercepting pointer events for swipe detection, treating slight finger movement as swipe attempts
- Uses `handleOnly` prop to restrict drag detection to handle area only
- Adds `mobile` button size variant (44px) meeting iOS accessibility guidelines

## Test plan
- [ ] Test on iOS Safari - verify 10+ consecutive taps all register on first attempt
- [ ] Test on Android Chrome - same tap reliability check
- [ ] Verify drawer swipe-to-close still works via drag handle
- [ ] Test each ActionBar button type (Discard, Lay Down, Organize, Lay Off, May I)
- [ ] Verify desktop click behavior unchanged

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)