### PR TITLE
feat: Improve round completion dialog with detailed summary (#56)

### DIFF
--- a/app/party/ai-turn-coordinator.ts
+++ b/app/party/ai-turn-coordinator.ts
@@ -91,7 +91,8 @@ export interface AITurnEventCallbacks {
   onTransitionCheck?: (
     adapter: PartyGameAdapter,
     phaseBefore: string,
-    roundBefore: number
+    roundBefore: number,
+    snapshotBefore: import("../../core/engine/game-engine.types").GameSnapshot
   ) => Promise<void>;
 }
 
@@ -225,7 +226,7 @@ export class AITurnCoordinator {
 
           // Check for round/game end transitions
           if (callbacks?.onTransitionCheck) {
-            await callbacks.onTransitionCheck(adapter, phaseBefore, roundBefore);
+            await callbacks.onTransitionCheck(adapter, phaseBefore, roundBefore, snapshotBefore);
           }
 
           // Broadcast updated game state

--- a/app/party/mayi-room.message-handlers.ts
+++ b/app/party/mayi-room.message-handlers.ts
@@ -119,6 +119,8 @@ export type GameActionSideEffect =
       adapter: PartyGameAdapter;
       phaseBefore: string;
       roundBefore: number;
+      /** Snapshot captured BEFORE action - used for round summary */
+      snapshotBefore: import("../../core/engine/game-engine.types").GameSnapshot;
     }
   | { type: "broadcastMayIPrompt"; adapter: PartyGameAdapter }
   | { type: "executeAIMayIResponseIfNeeded"; adapter: PartyGameAdapter }
@@ -460,6 +462,7 @@ export function handleGameActionMessage(args: {
     adapter,
     phaseBefore,
     roundBefore,
+    snapshotBefore,
   });
   sideEffects.push({ type: "broadcastGameState" });
 

--- a/app/party/protocol.types.ts
+++ b/app/party/protocol.types.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import type { Card } from "../../core/card/card.types";
 import type { Meld } from "../../core/meld/meld.types";
 import type { PlayerView, MeldSpec } from "../../core/engine/game-engine.types";
+import type { RoundSummaryPayload } from "./round-summary.types";
 import type { RoundNumber } from "../../core/engine/engine.types";
 import type { Contract } from "../../core/engine/contracts";
 import type { AgentTestState } from "./agent-state.types";
@@ -297,6 +298,8 @@ export interface RoundEndedMessage {
   scores: Record<string, number>;
   /** Map of lobby player IDs to display names */
   playerNames: Record<string, string>;
+  /** Full round summary payload for detailed display */
+  summary: RoundSummaryPayload;
 }
 
 export interface GameEndedMessage {

--- a/app/party/round-summary.capture.test.ts
+++ b/app/party/round-summary.capture.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "bun:test";
+import { captureRoundSummary } from "./round-summary.capture";
+import type { GameSnapshot } from "../../core/engine/game-engine.types";
+import type { PlayerMapping } from "./party-game-adapter";
+import type { Card, Rank, Suit } from "../../core/card/card.types";
+import type { Meld } from "../../core/meld/meld.types";
+
+// Rank mapping for test convenience
+const rankMap: Record<number, Rank> = {
+  2: "2", 3: "3", 4: "4", 5: "5", 6: "6", 7: "7", 8: "8", 9: "9", 10: "10",
+  11: "J", 12: "Q", 13: "K", 14: "A",
+};
+
+// Helper to create a mock card
+function mockCard(id: string, rankNum: number, suit: Suit): Card {
+  return {
+    id,
+    rank: rankMap[rankNum] ?? "A",
+    suit,
+  };
+}
+
+// Helper to create a mock meld
+function mockMeld(id: string, ownerId: string, cards: Card[], type: "set" | "run"): Meld {
+  return {
+    id,
+    type,
+    cards,
+    ownerId,
+  };
+}
+
+// Helper to create a minimal valid GameSnapshot for testing
+function createTestSnapshot(overrides: Partial<GameSnapshot>): GameSnapshot {
+  return {
+    version: "3.0",
+    gameId: "test-game",
+    lastError: null,
+    phase: "ROUND_ACTIVE",
+    turnPhase: "AWAITING_DRAW",
+    turnNumber: 1,
+    lastDiscardedByPlayerId: null,
+    discardClaimed: false,
+    currentRound: 1,
+    contract: { roundNumber: 1, sets: 2, runs: 0 },
+    players: [],
+    dealerIndex: 0,
+    currentPlayerIndex: 0,
+    awaitingPlayerId: "player-0",
+    stock: [],
+    discard: [],
+    table: [],
+    hasDrawn: false,
+    laidDownThisTurn: false,
+    tookActionThisTurn: false,
+    mayIContext: null,
+    roundHistory: [],
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("captureRoundSummary", () => {
+  it("captures basic round summary with winner, melds, hands, and scores", () => {
+    // Setup: 3-player game where player-1 went out
+    const snapshot = createTestSnapshot({
+      currentRound: 1,
+      turnNumber: 5,
+      table: [
+        mockMeld("meld-1", "player-0", [mockCard("c1", 7, "hearts"), mockCard("c2", 7, "spades"), mockCard("c3", 7, "diamonds")], "set"),
+        mockMeld("meld-2", "player-1", [mockCard("c4", 3, "clubs"), mockCard("c5", 4, "clubs"), mockCard("c6", 5, "clubs")], "run"),
+      ],
+      players: [
+        {
+          id: "player-0",
+          name: "Alice",
+          hand: [mockCard("h1", 10, "hearts"), mockCard("h2", 5, "spades")],
+          isDown: true,
+          totalScore: 25,
+        },
+        {
+          id: "player-1",
+          name: "Bob",
+          hand: [], // Winner - went out
+          isDown: true,
+          totalScore: 10,
+        },
+        {
+          id: "player-2",
+          name: "Charlie",
+          hand: [mockCard("h3", 2, "diamonds"), mockCard("h4", 8, "clubs"), mockCard("h5", 9, "hearts")],
+          isDown: false,
+          totalScore: 50,
+        },
+      ],
+      currentPlayerIndex: 1,
+    });
+
+    const playerMappings: PlayerMapping[] = [
+      { lobbyId: "lobby-alice", engineId: "player-0", name: "Alice", avatarId: "avatar-a", isAI: false },
+      { lobbyId: "lobby-bob", engineId: "player-1", name: "Bob", avatarId: "avatar-b", isAI: true, aiModelId: "grok" },
+      { lobbyId: "lobby-charlie", engineId: "player-2", name: "Charlie", isAI: false },
+    ];
+
+    const result = captureRoundSummary(snapshot, playerMappings);
+
+    // Verify winner is the player who went out (empty hand)
+    expect(result.winnerId).toBe("lobby-bob");
+
+    // Verify table melds are captured
+    expect(result.tableMelds).toHaveLength(2);
+    expect(result.tableMelds[0]?.id).toBe("meld-1");
+    expect(result.tableMelds[1]?.id).toBe("meld-2");
+
+    // Verify player hands are mapped to lobby IDs
+    expect(result.playerHands["lobby-alice"]).toHaveLength(2);
+    expect(result.playerHands["lobby-bob"]).toHaveLength(0);
+    expect(result.playerHands["lobby-charlie"]).toHaveLength(3);
+
+    // Verify scores are mapped to lobby IDs
+    expect(result.scores["lobby-alice"]).toBe(25);
+    expect(result.scores["lobby-bob"]).toBe(10);
+    expect(result.scores["lobby-charlie"]).toBe(50);
+
+    // Verify player names are mapped
+    expect(result.playerNames["lobby-alice"]).toBe("Alice");
+    expect(result.playerNames["lobby-bob"]).toBe("Bob");
+    expect(result.playerNames["lobby-charlie"]).toBe("Charlie");
+
+    // Verify avatars are mapped (including undefined)
+    expect(result.playerAvatars["lobby-alice"]).toBe("avatar-a");
+    expect(result.playerAvatars["lobby-bob"]).toBe("avatar-b");
+    expect(result.playerAvatars["lobby-charlie"]).toBeUndefined();
+  });
+
+  it("handles winner going out with 0 cards - winner is detected correctly", () => {
+    const snapshot = createTestSnapshot({
+      currentRound: 2,
+      turnNumber: 8,
+      contract: { roundNumber: 2, sets: 1, runs: 1 },
+      players: [
+        { id: "player-0", name: "P1", hand: [], isDown: true, totalScore: 0 },
+        { id: "player-1", name: "P2", hand: [mockCard("x1", 5, "hearts")], isDown: true, totalScore: 20 },
+      ],
+      currentPlayerIndex: 0,
+    });
+
+    const playerMappings: PlayerMapping[] = [
+      { lobbyId: "winner", engineId: "player-0", name: "P1", isAI: false },
+      { lobbyId: "loser", engineId: "player-1", name: "P2", isAI: false },
+    ];
+
+    const result = captureRoundSummary(snapshot, playerMappings);
+
+    expect(result.winnerId).toBe("winner");
+    expect(result.playerHands["winner"]).toHaveLength(0);
+    expect(result.playerHands["loser"]).toHaveLength(1);
+  });
+
+  it("captures multiple melds per player correctly", () => {
+    const snapshot = createTestSnapshot({
+      currentRound: 3,
+      turnNumber: 10,
+      contract: { roundNumber: 3, sets: 0, runs: 2 },
+      table: [
+        mockMeld("m1", "player-0", [mockCard("a1", 4, "hearts"), mockCard("a2", 4, "spades"), mockCard("a3", 4, "diamonds")], "set"),
+        mockMeld("m2", "player-0", [mockCard("b1", 6, "clubs"), mockCard("b2", 7, "clubs"), mockCard("b3", 8, "clubs")], "run"),
+        mockMeld("m3", "player-1", [mockCard("c1", 10, "hearts"), mockCard("c2", 10, "spades"), mockCard("c3", 10, "diamonds")], "set"),
+      ],
+      players: [
+        { id: "player-0", name: "Multi", hand: [], isDown: true, totalScore: 15 },
+        { id: "player-1", name: "Single", hand: [mockCard("d1", 2, "hearts")], isDown: true, totalScore: 30 },
+      ],
+      currentPlayerIndex: 0,
+    });
+
+    const playerMappings: PlayerMapping[] = [
+      { lobbyId: "player-multi", engineId: "player-0", name: "Multi", isAI: false },
+      { lobbyId: "player-single", engineId: "player-1", name: "Single", isAI: false },
+    ];
+
+    const result = captureRoundSummary(snapshot, playerMappings);
+
+    // All melds should be captured
+    expect(result.tableMelds).toHaveLength(3);
+    // First two melds belong to player-0
+    expect(result.tableMelds.filter(m => m.ownerId === "player-0")).toHaveLength(2);
+    // Third meld belongs to player-1
+    expect(result.tableMelds.filter(m => m.ownerId === "player-1")).toHaveLength(1);
+  });
+
+  it("handles player with 15+ remaining cards", () => {
+    const suits = ["hearts", "spades", "diamonds", "clubs"] as const;
+    const manyCards = Array.from({ length: 17 }, (_, i) =>
+      mockCard(`card-${i}`, (i % 10) + 3, suits[i % 4] as Suit)
+    );
+
+    const snapshot = createTestSnapshot({
+      currentRound: 1,
+      turnNumber: 3,
+      players: [
+        { id: "player-0", name: "Winner", hand: [], isDown: true, totalScore: 0 },
+        { id: "player-1", name: "ManyCards", hand: manyCards, isDown: false, totalScore: 100 },
+      ],
+      currentPlayerIndex: 0,
+    });
+
+    const playerMappings: PlayerMapping[] = [
+      { lobbyId: "winner", engineId: "player-0", name: "Winner", isAI: false },
+      { lobbyId: "loser", engineId: "player-1", name: "ManyCards", isAI: false },
+    ];
+
+    const result = captureRoundSummary(snapshot, playerMappings);
+
+    expect(result.playerHands["loser"]).toHaveLength(17);
+  });
+});

--- a/app/party/round-summary.capture.ts
+++ b/app/party/round-summary.capture.ts
@@ -1,0 +1,72 @@
+/**
+ * Round Summary Capture
+ *
+ * Pure function to capture round summary state BEFORE round transition.
+ * This ensures we capture hands and table state at the moment the round ends,
+ * avoiding race conditions where state could change during UI transitions.
+ */
+
+import type { GameSnapshot } from "../../core/engine/game-engine.types";
+import type { PlayerMapping } from "./party-game-adapter";
+import type { RoundSummaryPayload } from "./round-summary.types";
+
+/**
+ * Capture a snapshot of the round state for display in the round summary dialog.
+ *
+ * IMPORTANT: This must be called BEFORE the round transition to avoid race conditions.
+ * The snapshot should be taken when a player goes out (hand becomes empty) but before
+ * the engine starts the next round.
+ *
+ * @param snapshot - The game snapshot at the moment the round ends
+ * @param playerMappings - Player mappings for ID translation
+ * @returns RoundSummaryPayload with all display information
+ */
+export function captureRoundSummary(
+  snapshot: GameSnapshot,
+  playerMappings: PlayerMapping[]
+): RoundSummaryPayload {
+  // Find the winner (player with empty hand who went out)
+  const winnerEnginePlayer = snapshot.players.find((p) => p.hand.length === 0);
+  const winnerMapping = playerMappings.find(
+    (m) => m.engineId === winnerEnginePlayer?.id
+  );
+  const winnerId = winnerMapping?.lobbyId ?? "";
+
+  // Capture table melds as-is (they already have ownerIds)
+  const tableMelds = [...snapshot.table];
+
+  // Build player hands map (lobbyId -> cards)
+  const playerHands: Record<string, typeof snapshot.players[0]["hand"]> = {};
+  for (const mapping of playerMappings) {
+    const player = snapshot.players.find((p) => p.id === mapping.engineId);
+    playerHands[mapping.lobbyId] = player?.hand ?? [];
+  }
+
+  // Build scores map (lobbyId -> totalScore)
+  const scores: Record<string, number> = {};
+  for (const mapping of playerMappings) {
+    const player = snapshot.players.find((p) => p.id === mapping.engineId);
+    scores[mapping.lobbyId] = player?.totalScore ?? 0;
+  }
+
+  // Build player names map (lobbyId -> name)
+  const playerNames: Record<string, string> = {};
+  for (const mapping of playerMappings) {
+    playerNames[mapping.lobbyId] = mapping.name;
+  }
+
+  // Build player avatars map (lobbyId -> avatarId)
+  const playerAvatars: Record<string, string | undefined> = {};
+  for (const mapping of playerMappings) {
+    playerAvatars[mapping.lobbyId] = mapping.avatarId;
+  }
+
+  return {
+    winnerId,
+    tableMelds,
+    playerHands,
+    scores,
+    playerNames,
+    playerAvatars,
+  };
+}

--- a/app/party/round-summary.types.ts
+++ b/app/party/round-summary.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Round Summary Types
+ *
+ * Types for capturing and displaying round end summary information.
+ * Used by RoundSummaryDialog to show winner, scores, table melds, and remaining cards.
+ */
+
+import type { Card } from "../../core/card/card.types";
+import type { Meld } from "../../core/meld/meld.types";
+
+/**
+ * Payload containing all information needed to display round summary.
+ * Captured BEFORE round transition to avoid race conditions.
+ */
+export interface RoundSummaryPayload {
+  /** Lobby ID of the player who went out */
+  winnerId: string;
+  /** All melds on the table at round end */
+  tableMelds: Meld[];
+  /** Map of lobby player IDs to their remaining cards */
+  playerHands: Record<string, Card[]>;
+  /** Map of lobby player IDs to their current total scores */
+  scores: Record<string, number>;
+  /** Map of lobby player IDs to their display names */
+  playerNames: Record<string, string>;
+  /** Map of lobby player IDs to their avatar IDs */
+  playerAvatars: Record<string, string | undefined>;
+}

--- a/app/routes/game.$roomId.tsx
+++ b/app/routes/game.$roomId.tsx
@@ -21,7 +21,7 @@ import {
 import { LobbyView } from "~/ui/lobby/LobbyView";
 import { GameView } from "~/ui/game-view/GameView";
 import { MayIPromptDialog } from "~/ui/may-i-request/MayIPromptDialog";
-import { RoundEndOverlay } from "~/ui/game-transitions/RoundEndOverlay";
+import { RoundSummaryDialog } from "~/ui/round-summary/RoundSummaryDialog";
 import { GameEndScreen } from "~/ui/game-transitions/GameEndScreen";
 import { usePartyConnection } from "~/hooks/usePartyConnection";
 import type {
@@ -39,6 +39,7 @@ import type {
   GameAction,
   ActivityLogEntry,
 } from "~/party/protocol.types";
+import type { RoundSummaryPayload } from "~/party/round-summary.types";
 import type { Card } from "core/card/card.types";
 import { formatCardText } from "core/card/card-text.utils";
 import { useAgentHarnessSetup } from "~/ui/agent-harness/useAgentHarnessSetup";
@@ -134,6 +135,7 @@ export default function Game({ loaderData }: Route.ComponentProps) {
     roundNumber: number;
     scores: Record<string, number>;
     playerNames: Record<string, string>;
+    summary: RoundSummaryPayload;
   } | null>(null);
 
   const [gameEndData, setGameEndData] = useState<{
@@ -577,12 +579,13 @@ export default function Game({ loaderData }: Route.ComponentProps) {
             roundNumber: msg.roundNumber,
             scores: msg.scores,
             playerNames: msg.playerNames,
+            summary: msg.summary,
           });
-          // Auto-clear after countdown (4 seconds + 500ms buffer)
+          // Auto-clear after countdown (15 seconds + 500ms buffer)
           roundEndTimeoutRef.current = setTimeout(() => {
             setRoundEndData(null);
             roundEndTimeoutRef.current = null;
-          }, 4500);
+          }, 15500);
           return;
         }
         case "GAME_ENDED": {
@@ -687,13 +690,18 @@ export default function Game({ loaderData }: Route.ComponentProps) {
             }}
           />
         )}
-        {/* Phase 3.8: Round End Overlay */}
+        {/* Phase 3.8: Round Summary Dialog */}
         {roundEndData && !gameEndData && (
-          <RoundEndOverlay
+          <RoundSummaryDialog
             roundNumber={roundEndData.roundNumber}
+            winnerId={roundEndData.summary.winnerId}
+            tableMelds={roundEndData.summary.tableMelds}
+            playerHands={roundEndData.summary.playerHands}
             scores={roundEndData.scores}
             playerNames={roundEndData.playerNames}
+            playerAvatars={roundEndData.summary.playerAvatars}
             currentPlayerId={currentPlayerId ?? ""}
+            countdownSeconds={15}
           />
         )}
         {/* Phase 3.8: Game End Screen */}

--- a/app/ui/round-summary/RemainingHandsDisplay.story.tsx
+++ b/app/ui/round-summary/RemainingHandsDisplay.story.tsx
@@ -1,0 +1,104 @@
+import type { Card, Rank, Suit } from "core/card/card.types";
+import { RemainingHandsDisplay } from "./RemainingHandsDisplay";
+
+// Rank mapping for story convenience
+const rankMap: Record<number, Rank> = {
+  2: "2", 3: "3", 4: "4", 5: "5", 6: "6", 7: "7", 8: "8", 9: "9", 10: "10",
+  11: "J", 12: "Q", 13: "K", 14: "A",
+};
+
+// Helper to create mock cards
+function mockCard(id: string, rankNum: number, suit: Suit): Card {
+  return {
+    id,
+    rank: rankMap[rankNum] ?? "A",
+    suit,
+  };
+}
+
+export function RemainingHandsDisplayStory() {
+  const playerNames = {
+    "alice": "Alice",
+    "bob": "Bob",
+    "charlie": "Charlie",
+  };
+
+  const playerHands: Record<string, Card[]> = {
+    "alice": [], // Winner - went out
+    "bob": [
+      mockCard("b1", 7, "hearts"),
+      mockCard("b2", 10, "spades"),
+      mockCard("b3", 3, "diamonds"),
+    ],
+    "charlie": [
+      mockCard("c1", 5, "clubs"),
+      mockCard("c2", 8, "hearts"),
+      mockCard("c3", 2, "spades"),
+      mockCard("c4", 9, "diamonds"),
+      mockCard("c5", 4, "clubs"),
+    ],
+  };
+
+  const suits = ["hearts", "spades", "diamonds", "clubs"] as const;
+  const manyCards: Card[] = Array.from({ length: 12 }, (_, i) =>
+    mockCard(`m${i}`, (i % 10) + 3, suits[i % 4] as Suit)
+  );
+
+  return (
+    <div className="space-y-8 p-4">
+      <h2 className="text-lg font-semibold">RemainingHandsDisplay</h2>
+
+      <div className="space-y-6">
+        {/* Normal case */}
+        <div className="border rounded-lg p-4 max-w-md">
+          <p className="text-sm text-muted-foreground mb-4">
+            Alice went out, Bob and Charlie have remaining cards
+          </p>
+          <RemainingHandsDisplay
+            playerHands={playerHands}
+            playerNames={playerNames}
+            winnerId="alice"
+            currentPlayerId="bob"
+          />
+        </div>
+
+        {/* Many cards */}
+        <div className="border rounded-lg p-4 max-w-md">
+          <p className="text-sm text-muted-foreground mb-4">
+            Player with many remaining cards (12)
+          </p>
+          <RemainingHandsDisplay
+            playerHands={{
+              "winner": [],
+              "unlucky": manyCards,
+            }}
+            playerNames={{
+              "winner": "Winner",
+              "unlucky": "Unlucky Player",
+            }}
+            winnerId="winner"
+            currentPlayerId="unlucky"
+          />
+        </div>
+
+        {/* You are the winner */}
+        <div className="border rounded-lg p-4 max-w-md">
+          <p className="text-sm text-muted-foreground mb-4">
+            You went out (you = alice), others have cards
+          </p>
+          <RemainingHandsDisplay
+            playerHands={playerHands}
+            playerNames={playerNames}
+            winnerId="alice"
+            currentPlayerId="alice"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const meta = {
+  title: "RemainingHandsDisplay",
+  component: RemainingHandsDisplay,
+};

--- a/app/ui/round-summary/RemainingHandsDisplay.tsx
+++ b/app/ui/round-summary/RemainingHandsDisplay.tsx
@@ -1,0 +1,78 @@
+import type { Card } from "core/card/card.types";
+import { getPointValue } from "core/card/card.utils";
+import { PlayingCard } from "~/ui/playing-card/PlayingCard";
+import { cn } from "~/shadcn/lib/utils";
+
+interface RemainingHandsDisplayProps {
+  /** Map of player ID to their remaining cards */
+  playerHands: Record<string, Card[]>;
+  /** Map of player ID to display name */
+  playerNames: Record<string, string>;
+  /** ID of the player who went out (they have 0 cards) */
+  winnerId: string;
+  /** ID of the viewing player (for "(You)" label) */
+  currentPlayerId: string;
+  className?: string;
+}
+
+export function RemainingHandsDisplay({
+  playerHands,
+  playerNames,
+  winnerId,
+  currentPlayerId,
+  className,
+}: RemainingHandsDisplayProps) {
+  // Filter out the winner (they have 0 cards) and sort by name
+  const playersWithCards = Object.entries(playerHands)
+    .filter(([playerId]) => playerId !== winnerId)
+    .sort(([, a], [, b]) => b.length - a.length); // Most cards first
+
+  if (playersWithCards.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("space-y-3", className)}>
+      <h3 className="text-sm font-medium text-muted-foreground">
+        Remaining Cards
+      </h3>
+      <div className="space-y-3">
+        {playersWithCards.map(([playerId, cards]) => {
+          const name = playerNames[playerId] ?? "Unknown";
+          const isYou = playerId === currentPlayerId;
+          const pointsInHand = cards.reduce((sum, card) => sum + getPointValue(card), 0);
+
+          return (
+            <div key={playerId} className="space-y-1.5">
+              {/* Player name and point count */}
+              <div className="flex items-baseline justify-between">
+                <span className={cn("text-sm", isYou && "font-semibold")}>
+                  {isYou ? `${name} (You)` : name}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  +{pointsInHand} pts
+                </span>
+              </div>
+
+              {/* Cards display */}
+              <div className="flex flex-wrap gap-0.5">
+                {cards.map((card, index) => (
+                  <div
+                    key={card.id}
+                    className={cn(
+                      index > 0 && "-ml-4",
+                      "relative"
+                    )}
+                    style={{ zIndex: index }}
+                  >
+                    <PlayingCard card={card} size="sm" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/ui/round-summary/RoundSummaryDialog.story.tsx
+++ b/app/ui/round-summary/RoundSummaryDialog.story.tsx
@@ -1,0 +1,128 @@
+import type { Card, Rank, Suit } from "core/card/card.types";
+import type { Meld } from "core/meld/meld.types";
+import { RoundSummaryDialog } from "./RoundSummaryDialog";
+
+// Rank mapping for story convenience
+const rankMap: Record<number, Rank> = {
+  2: "2", 3: "3", 4: "4", 5: "5", 6: "6", 7: "7", 8: "8", 9: "9", 10: "10",
+  11: "J", 12: "Q", 13: "K", 14: "A",
+};
+
+// Helper to create mock cards
+function mockCard(id: string, rankNum: number, suit: Suit): Card {
+  return {
+    id,
+    rank: rankMap[rankNum] ?? "A",
+    suit,
+  };
+}
+
+// Helper to create mock meld
+function mockMeld(id: string, ownerId: string, cards: Card[], type: "set" | "run"): Meld {
+  return {
+    id,
+    type,
+    cards,
+    ownerId,
+  };
+}
+
+export function RoundSummaryDialogStory() {
+  const playerNames = {
+    "alice": "Alice",
+    "bob": "Bob",
+    "charlie": "Charlie",
+  };
+
+  const playerAvatars = {
+    "alice": "ethel",
+    "bob": "curt",
+    "charlie": undefined,
+  };
+
+  const scores = {
+    "alice": 25,
+    "bob": 0,
+    "charlie": 45,
+  };
+
+  const tableMelds: Meld[] = [
+    mockMeld("m1", "alice", [
+      mockCard("c1", 7, "hearts"),
+      mockCard("c2", 7, "spades"),
+      mockCard("c3", 7, "diamonds"),
+    ], "set"),
+    mockMeld("m2", "bob", [
+      mockCard("c4", 3, "clubs"),
+      mockCard("c5", 4, "clubs"),
+      mockCard("c6", 5, "clubs"),
+    ], "run"),
+    mockMeld("m3", "charlie", [
+      mockCard("c7", 10, "hearts"),
+      mockCard("c8", 10, "spades"),
+      mockCard("c9", 10, "diamonds"),
+    ], "set"),
+  ];
+
+  const playerHands: Record<string, Card[]> = {
+    "alice": [
+      mockCard("h1", 8, "hearts"),
+      mockCard("h2", 2, "spades"),
+    ],
+    "bob": [], // Winner
+    "charlie": [
+      mockCard("h3", 5, "diamonds"),
+      mockCard("h4", 9, "clubs"),
+      mockCard("h5", 3, "hearts"),
+      mockCard("h6", 6, "spades"),
+    ],
+  };
+
+  return (
+    <div className="space-y-8 p-4">
+      <h2 className="text-lg font-semibold">RoundSummaryDialog</h2>
+      <p className="text-sm text-muted-foreground">
+        This component is typically shown as a full-screen overlay.
+        Below is a static preview of the dialog content.
+      </p>
+
+      {/* Full dialog preview (constrained for story) */}
+      <div className="border rounded-lg relative h-[600px] overflow-hidden">
+        <RoundSummaryDialog
+          roundNumber={3}
+          winnerId="bob"
+          tableMelds={tableMelds}
+          playerHands={playerHands}
+          scores={scores}
+          playerNames={playerNames}
+          playerAvatars={playerAvatars}
+          currentPlayerId="alice"
+          countdownSeconds={15}
+        />
+      </div>
+
+      {/* You are the winner */}
+      <div className="border rounded-lg relative h-[600px] overflow-hidden">
+        <p className="absolute top-2 left-2 text-xs text-muted-foreground z-[60] bg-background px-2 py-1 rounded">
+          You (Bob) won this round
+        </p>
+        <RoundSummaryDialog
+          roundNumber={1}
+          winnerId="bob"
+          tableMelds={tableMelds}
+          playerHands={playerHands}
+          scores={scores}
+          playerNames={playerNames}
+          playerAvatars={playerAvatars}
+          currentPlayerId="bob"
+          countdownSeconds={15}
+        />
+      </div>
+    </div>
+  );
+}
+
+export const meta = {
+  title: "RoundSummaryDialog",
+  component: RoundSummaryDialog,
+};

--- a/app/ui/round-summary/RoundSummaryDialog.tsx
+++ b/app/ui/round-summary/RoundSummaryDialog.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import type { Card } from "core/card/card.types";
+import type { Meld } from "core/meld/meld.types";
+import { Card as CardUI, CardContent, CardHeader } from "~/shadcn/components/ui/card";
+import { TableDisplay } from "~/ui/game-table/TableDisplay";
+import { WinnerBanner } from "./WinnerBanner";
+import { ScoreBreakdown } from "./ScoreBreakdown";
+import { RemainingHandsDisplay } from "./RemainingHandsDisplay";
+import { cn } from "~/shadcn/lib/utils";
+
+interface Player {
+  id: string;
+  name: string;
+  avatarId?: string;
+}
+
+interface RoundSummaryDialogProps {
+  /** Round number that just ended */
+  roundNumber: number;
+  /** Lobby ID of the player who went out */
+  winnerId: string;
+  /** All melds on the table at round end */
+  tableMelds: Meld[];
+  /** Map of lobby player IDs to their remaining cards */
+  playerHands: Record<string, Card[]>;
+  /** Map of lobby player IDs to their current total scores */
+  scores: Record<string, number>;
+  /** Map of lobby player IDs to their display names */
+  playerNames: Record<string, string>;
+  /** Map of lobby player IDs to their avatar IDs */
+  playerAvatars: Record<string, string | undefined>;
+  /** The viewing player's lobby ID */
+  currentPlayerId: string;
+  /** Duration of the countdown in seconds (default: 15) */
+  countdownSeconds?: number;
+  className?: string;
+}
+
+export function RoundSummaryDialog({
+  roundNumber,
+  winnerId,
+  tableMelds,
+  playerHands,
+  scores,
+  playerNames,
+  playerAvatars,
+  currentPlayerId,
+  countdownSeconds = 15,
+  className,
+}: RoundSummaryDialogProps) {
+  const [countdown, setCountdown] = useState(countdownSeconds);
+
+  // Countdown timer - no callback, no manual dismiss
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCountdown((prev) => (prev <= 1 ? 0 : prev - 1));
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, []); // Empty deps - runs once on mount
+
+  const winnerName = playerNames[winnerId] ?? "Unknown";
+  const isYouWinner = winnerId === currentPlayerId;
+
+  // Build players array for TableDisplay
+  const players: Player[] = Object.entries(playerNames).map(([id, name]) => ({
+    id,
+    name,
+    avatarId: playerAvatars[id],
+  }));
+
+  // Check if there are any melds to display
+  const hasMelds = tableMelds.length > 0;
+
+  return (
+    <div
+      className={cn(
+        "fixed inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm overflow-auto py-4",
+        className
+      )}
+    >
+      <CardUI className="w-full max-w-2xl mx-4 animate-in fade-in zoom-in duration-300 max-h-[90vh] overflow-auto">
+        <CardHeader className="pb-2">
+          <WinnerBanner
+            winnerName={winnerName}
+            isYou={isYouWinner}
+            roundNumber={roundNumber}
+          />
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          {/* Scores */}
+          <ScoreBreakdown
+            scores={scores}
+            playerNames={playerNames}
+            winnerId={winnerId}
+            currentPlayerId={currentPlayerId}
+          />
+
+          {/* Table melds (if any) */}
+          {hasMelds && (
+            <div className="space-y-2">
+              <h3 className="text-sm font-medium text-muted-foreground">
+                Table Melds
+              </h3>
+              <div className="border rounded-lg p-3 bg-muted/30">
+                <TableDisplay
+                  melds={tableMelds}
+                  players={players}
+                  viewingPlayerId={currentPlayerId}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Remaining cards */}
+          <RemainingHandsDisplay
+            playerHands={playerHands}
+            playerNames={playerNames}
+            winnerId={winnerId}
+            currentPlayerId={currentPlayerId}
+          />
+
+          {/* Next round countdown */}
+          <div className="text-center text-sm text-muted-foreground pt-2 border-t">
+            {countdown > 0
+              ? `Next round starting in ${countdown}...`
+              : "Starting now..."}
+          </div>
+        </CardContent>
+      </CardUI>
+    </div>
+  );
+}

--- a/app/ui/round-summary/ScoreBreakdown.story.tsx
+++ b/app/ui/round-summary/ScoreBreakdown.story.tsx
@@ -1,0 +1,77 @@
+import { ScoreBreakdown } from "./ScoreBreakdown";
+
+export function ScoreBreakdownStory() {
+  const scores = {
+    "player-1": 45,
+    "player-2": 12,
+    "player-3": 78,
+    "player-4": 25,
+  };
+
+  const playerNames = {
+    "player-1": "Alice",
+    "player-2": "Bob",
+    "player-3": "Charlie",
+    "player-4": "Diana",
+  };
+
+  return (
+    <div className="space-y-8 p-4">
+      <h2 className="text-lg font-semibold">ScoreBreakdown</h2>
+
+      <div className="space-y-6">
+        {/* Winner is not you */}
+        <div className="border rounded-lg p-4 max-w-sm">
+          <p className="text-sm text-muted-foreground mb-4">
+            Bob went out, you are Alice
+          </p>
+          <ScoreBreakdown
+            scores={scores}
+            playerNames={playerNames}
+            winnerId="player-2"
+            currentPlayerId="player-1"
+          />
+        </div>
+
+        {/* Winner is you */}
+        <div className="border rounded-lg p-4 max-w-sm">
+          <p className="text-sm text-muted-foreground mb-4">
+            You (Alice) went out
+          </p>
+          <ScoreBreakdown
+            scores={scores}
+            playerNames={playerNames}
+            winnerId="player-1"
+            currentPlayerId="player-1"
+          />
+        </div>
+
+        {/* Tight scores */}
+        <div className="border rounded-lg p-4 max-w-sm">
+          <p className="text-sm text-muted-foreground mb-4">
+            Close game (similar scores)
+          </p>
+          <ScoreBreakdown
+            scores={{
+              "p1": 100,
+              "p2": 102,
+              "p3": 98,
+            }}
+            playerNames={{
+              "p1": "Alice",
+              "p2": "Bob",
+              "p3": "Charlie",
+            }}
+            winnerId="p3"
+            currentPlayerId="p1"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const meta = {
+  title: "ScoreBreakdown",
+  component: ScoreBreakdown,
+};

--- a/app/ui/round-summary/ScoreBreakdown.tsx
+++ b/app/ui/round-summary/ScoreBreakdown.tsx
@@ -1,0 +1,70 @@
+import { Trophy } from "lucide-react";
+import { cn } from "~/shadcn/lib/utils";
+
+interface ScoreBreakdownProps {
+  /** Map of player ID to score */
+  scores: Record<string, number>;
+  /** Map of player ID to display name */
+  playerNames: Record<string, string>;
+  /** ID of the player who went out this round */
+  winnerId: string;
+  /** ID of the viewing player (for "(You)" label) */
+  currentPlayerId: string;
+  className?: string;
+}
+
+export function ScoreBreakdown({
+  scores,
+  playerNames,
+  winnerId,
+  currentPlayerId,
+  className,
+}: ScoreBreakdownProps) {
+  // Sort players by score (ascending - lowest is best)
+  const sortedPlayers = Object.entries(scores).sort(([, a], [, b]) => a - b);
+
+  return (
+    <div className={cn("space-y-2", className)}>
+      <h3 className="text-sm font-medium text-muted-foreground">
+        Current Standings
+      </h3>
+      <div className="divide-y rounded-lg border">
+        {sortedPlayers.map(([playerId, score], index) => {
+          const name = playerNames[playerId] ?? "Unknown";
+          const isYou = playerId === currentPlayerId;
+          const isWinner = playerId === winnerId;
+          return (
+            <div
+              key={playerId}
+              className={cn(
+                "flex items-center justify-between py-2.5 px-3",
+                isWinner && "bg-primary/5",
+                isYou && "font-semibold"
+              )}
+            >
+              <div className="flex items-center gap-2.5">
+                <span
+                  className={cn(
+                    "w-5 h-5 rounded-full flex items-center justify-center text-xs",
+                    index === 0
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground"
+                  )}
+                >
+                  {index + 1}
+                </span>
+                <span className="flex items-center gap-1">
+                  {isYou ? `${name} (You)` : name}
+                  {isWinner && (
+                    <Trophy className="w-3.5 h-3.5 text-primary" />
+                  )}
+                </span>
+              </div>
+              <span className="tabular-nums">{score} pts</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/ui/round-summary/WinnerBanner.story.tsx
+++ b/app/ui/round-summary/WinnerBanner.story.tsx
@@ -1,0 +1,46 @@
+import { WinnerBanner } from "./WinnerBanner";
+
+export function WinnerBannerStory() {
+  return (
+    <div className="space-y-8 p-4">
+      <h2 className="text-lg font-semibold">WinnerBanner</h2>
+
+      <div className="space-y-6">
+        {/* You won */}
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground mb-4">You went out (winner is you)</p>
+          <WinnerBanner
+            winnerName="Alice"
+            isYou={true}
+            roundNumber={3}
+          />
+        </div>
+
+        {/* Someone else won */}
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground mb-4">Someone else went out</p>
+          <WinnerBanner
+            winnerName="Bob"
+            isYou={false}
+            roundNumber={1}
+          />
+        </div>
+
+        {/* Final round */}
+        <div className="border rounded-lg p-4">
+          <p className="text-sm text-muted-foreground mb-4">Final round (Round 6)</p>
+          <WinnerBanner
+            winnerName="Charlie"
+            isYou={false}
+            roundNumber={6}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export const meta = {
+  title: "WinnerBanner",
+  component: WinnerBanner,
+};

--- a/app/ui/round-summary/WinnerBanner.tsx
+++ b/app/ui/round-summary/WinnerBanner.tsx
@@ -1,0 +1,41 @@
+import { Trophy } from "lucide-react";
+import { cn } from "~/shadcn/lib/utils";
+
+interface WinnerBannerProps {
+  winnerName: string;
+  isYou: boolean;
+  roundNumber: number;
+  className?: string;
+}
+
+export function WinnerBanner({
+  winnerName,
+  isYou,
+  roundNumber,
+  className,
+}: WinnerBannerProps) {
+  return (
+    <div className={cn("text-center space-y-3", className)}>
+      {/* Trophy icon */}
+      <div className="mx-auto w-14 h-14 rounded-full bg-primary/10 flex items-center justify-center">
+        <Trophy className="w-7 h-7 text-primary" />
+      </div>
+
+      {/* Round complete title */}
+      <h2 className="text-xl font-semibold">Round {roundNumber} Complete!</h2>
+
+      {/* Winner announcement */}
+      <p className="text-lg text-muted-foreground">
+        {isYou ? (
+          <span className="text-primary font-semibold">
+            You went out!
+          </span>
+        ) : (
+          <>
+            <span className="font-semibold">{winnerName}</span> went out!
+          </>
+        )}
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `RoundSummaryDialog` with 15-second auto-dismiss timer showing round end details
- Display winner banner, score breakdown, and remaining cards in other players' hands
- Capture round summary state server-side and broadcast via WebSocket

## Changes
- New `app/ui/round-summary/` folder with RoundSummaryDialog, WinnerBanner, ScoreBreakdown, RemainingHandsDisplay components
- Server-side round summary capture in `app/party/round-summary.capture.ts`
- Integration with game route and PartyKit room

## Test plan
- [x] Unit tests for round summary capture (4 tests passing)
- [x] TypeScript compiles without errors
- [ ] Manual test: Complete a round and verify dialog appears with correct info
- [ ] Manual test: Dialog auto-dismisses after 15 seconds

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)